### PR TITLE
Use cStringIO.StringIO on Python 2

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+Pending
+-------
+
+* Fix modernize running on Python 2.
+
 1.0.0 (2016-06-19)
 ------------------
 

--- a/multilint/__init__.py
+++ b/multilint/__init__.py
@@ -6,14 +6,15 @@ from __future__ import (
 import os
 import subprocess
 import sys
-from io import StringIO
 
 from flake8.main import main as flake8_main
 
-try:
-    from configparser import SafeConfigParser  # Py 3
-except ImportError:
+if sys.version_info[0] == 2:
+    from cStringIO import StringIO
     from ConfigParser import SafeConfigParser  # Py 2
+else:
+    from configparser import SafeConfigParser  # Py 3
+    from io import StringIO
 
 try:
     from libmodernize.main import main as libmodernize_main

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 docutils==0.12
 flake8==2.6.0
 isort==4.2.5
+modernize==0.5
 py==1.4.31
 pycodestyle==2.0.0
 pyflakes==1.2.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,6 @@ exclude = docs
 
 [isort]
 multi_line_output = 5
+
+[multilint]
+paths = setup.py


### PR DESCRIPTION
Fixes modernize changes not working on Python 2.
