### PR TITLE
Rename config section to tool:multilint

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,9 @@ Pending
 -------
 
 * New notes here
+* Use the config header ``tool:multilint`` in ``setup.cfg``, rather than
+  ``multilint``, to avoid clashing with any potential ``setup.py`` commands.
+  Your ``setup.cfg`` will need updating.
 
 1.0.2 (2016-07-26)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ You need to configure the paths that will be linted (by default, only
 
 .. code-block:: ini
 
-    [multilint]
+    [tool:multilint]
     paths = my_package
             tests
             setup.py

--- a/multilint/__init__.py
+++ b/multilint/__init__.py
@@ -92,8 +92,8 @@ def _update_settings_from_file(section, settings):
         with open(config_file, 'rU') as fp:
             config = SafeConfigParser()
             config.readfp(fp)
-        if config.has_section('multilint'):
-            settings.update(sanitize(config.items('multilint')))
+        if config.has_section('tool:multilint'):
+            settings.update(sanitize(config.items('tool:multilint')))
 
 
 def sanitize(config_items):

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,5 +7,5 @@ exclude = docs
 [isort]
 multi_line_output = 5
 
-[multilint]
+[tool:multilint]
 paths = setup.py


### PR DESCRIPTION
Copy pytest, avoid any clash with setup.py commands. Fixes #6.
